### PR TITLE
Polish configuration properties

### DIFF
--- a/amqp-10-jms-spring-boot-autoconfigure/src/main/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSConnectionFactoryFactory.java
+++ b/amqp-10-jms-spring-boot-autoconfigure/src/main/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSConnectionFactoryFactory.java
@@ -21,6 +21,7 @@ import org.apache.qpid.jms.policy.JmsDefaultDeserializationPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -58,10 +59,7 @@ public class AMQP10JMSConnectionFactoryFactory {
         try {
             JmsConnectionFactory factory = new JmsConnectionFactory();
 
-            factory.setRemoteURI(getRemoteURI());
-
-            // Override the URI options with configuration values, but only if
-            // the value is actually set.
+            factory.setRemoteURI(properties.getBrokerUrl());
 
             if (StringUtils.hasLength(properties.getUsername())) {
                 factory.setUsername(properties.getUsername());
@@ -75,13 +73,9 @@ public class AMQP10JMSConnectionFactoryFactory {
                 factory.setClientID(properties.getClientId());
             }
 
-            if (properties.isReceiveLocalOnly() != null) {
-                factory.setReceiveLocalOnly(properties.isReceiveLocalOnly());
-            }
+            factory.setReceiveLocalOnly(properties.isReceiveLocalOnly());
 
-            if (properties.isReceiveNoWaitLocalOnly() != null) {
-                factory.setReceiveNoWaitLocalOnly(properties.isReceiveNoWaitLocalOnly());
-            }
+            factory.setReceiveNoWaitLocalOnly(properties.isReceiveNoWaitLocalOnly());
 
             configureDeserializationPolicy(properties, factory);
 
@@ -93,24 +87,18 @@ public class AMQP10JMSConnectionFactoryFactory {
         }
     }
 
-    public String getRemoteURI() {
-        if (StringUtils.hasLength(properties.getRemoteURL())) {
-            return properties.getRemoteURL();
-        } else {
-            return DEFAULT_REMOTE_URL;
-        }
-    }
-
     private void configureDeserializationPolicy(AMQP10JMSProperties properties, JmsConnectionFactory factory) {
         JmsDefaultDeserializationPolicy deserializationPolicy =
             (JmsDefaultDeserializationPolicy) factory.getDeserializationPolicy();
 
-        if (StringUtils.hasLength(properties.getDeserializationPolicy().getWhiteList())) {
-            deserializationPolicy.setWhiteList(properties.getDeserializationPolicy().getWhiteList());
+        if (!ObjectUtils.isEmpty(properties.getDeserializationPolicy().getWhiteList())) {
+            deserializationPolicy.setWhiteList(StringUtils.collectionToCommaDelimitedString(
+                    properties.getDeserializationPolicy().getWhiteList()));
         }
 
-        if (StringUtils.hasLength(properties.getDeserializationPolicy().getBlackList())) {
-            deserializationPolicy.setBlackList(properties.getDeserializationPolicy().getBlackList());
+        if (!ObjectUtils.isEmpty(properties.getDeserializationPolicy().getBlackList())) {
+            deserializationPolicy.setBlackList(StringUtils.collectionToCommaDelimitedString(
+                    properties.getDeserializationPolicy().getBlackList()));
         }
     }
 }

--- a/amqp-10-jms-spring-boot-autoconfigure/src/main/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSProperties.java
+++ b/amqp-10-jms-spring-boot-autoconfigure/src/main/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSProperties.java
@@ -18,28 +18,53 @@ package org.amqphub.spring.boot.jms.autoconfigure;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+
 /**
  * Configuration properties for the AMQP 1.0 JMS client
  */
 @ConfigurationProperties(prefix = "spring.amqp10jms")
 public class AMQP10JMSProperties {
 
-    private String remoteURL;
+    /**
+     * AMQP broker url.
+     */
+    private String brokerUrl = "amqp://localhost:5672";
+
+    /**
+     * AMQP broker username.
+     */
     private String username;
+
+    /**
+     * Login password of the AMQP broker.
+     */
     private String password;
+
+    /**
+     * JMS clientID to use for connections. A clientID can only be used by one Connection at a time, so setting it
+     * will restrict the ConnectionFactory to creating a single open Connection at a time.
+     */
     private String clientId;
 
-    private Boolean receiveLocalOnly;
-    private Boolean receiveNoWaitLocalOnly;
+    /**
+     * Whether the client only checks its local message buffer when using receive calls with a timeout.
+     */
+    private boolean receiveLocalOnly = false;
+
+    /**
+     * Whether the client only checks its local message buffer when using receiveNoWait calls.
+     */
+    private boolean receiveNoWaitLocalOnly = false;
 
     private final DeserializationPolicy deserializationPolicy = new DeserializationPolicy();
 
-    public String getRemoteURL() {
-        return remoteURL;
+    public String getBrokerUrl() {
+        return brokerUrl;
     }
 
-    public void setRemoteURL(String remoteURL) {
-        this.remoteURL = remoteURL;
+    public void setBrokerUrl(String remoteURL) {
+        this.brokerUrl = remoteURL;
     }
 
     public String getUsername() {
@@ -66,19 +91,19 @@ public class AMQP10JMSProperties {
         this.clientId = clientId;
     }
 
-    public Boolean isReceiveLocalOnly() {
+    public boolean isReceiveLocalOnly() {
         return receiveLocalOnly;
     }
 
-    public void setReceiveLocalOnly(Boolean receiveLocalOnly) {
+    public void setReceiveLocalOnly(boolean receiveLocalOnly) {
         this.receiveLocalOnly = receiveLocalOnly;
     }
 
-    public Boolean isReceiveNoWaitLocalOnly() {
+    public boolean isReceiveNoWaitLocalOnly() {
         return receiveNoWaitLocalOnly;
     }
 
-    public void setReceiveNoWaitLocalOnly(Boolean receiveNoWaitLocalOnly) {
+    public void setReceiveNoWaitLocalOnly(boolean receiveNoWaitLocalOnly) {
         this.receiveNoWaitLocalOnly = receiveNoWaitLocalOnly;
     }
 
@@ -88,22 +113,30 @@ public class AMQP10JMSProperties {
 
     public static class DeserializationPolicy {
 
-        private String whiteList;
-        private String blackList;
+        /**
+         * Whitelist of classes or packages.
+         */
+        private List<String> whiteList;
 
-        public String getWhiteList() {
-            return whiteList;
+        /**
+         * Blacklist of classes or packages. Blacklist overrides the whitelist, entries that could match both are
+         * counted as blacklisted.
+         */
+        private List<String> blackList;
+
+        public List<String> getWhiteList() {
+            return this.whiteList;
         }
 
-        public void setWhiteList(String whiteList) {
+        public void setWhiteList(List<String> whiteList) {
             this.whiteList = whiteList;
         }
 
-        public String getBlackList() {
-            return blackList;
+        public List<String> getBlackList() {
+            return this.blackList;
         }
 
-        public void setBlackList(String blackList) {
+        public void setBlackList(List<String> blackList) {
             this.blackList = blackList;
         }
     }

--- a/amqp-10-jms-spring-boot-autoconfigure/src/test/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSAutoConfigurationTest.java
+++ b/amqp-10-jms-spring-boot-autoconfigure/src/test/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSAutoConfigurationTest.java
@@ -66,7 +66,7 @@ public class AMQP10JMSAutoConfigurationTest {
     @Test
     public void testCustomConnectionFactorySettings() {
         load(EmptyConfiguration.class,
-             "spring.amqp10jms.remoteURL=amqp://127.0.0.1:5672",
+             "spring.amqp10jms.broker-url=amqp://127.0.0.1:5672",
              "spring.amqp10jms.username=foo",
              "spring.amqp10jms.password=bar");
 
@@ -99,7 +99,7 @@ public class AMQP10JMSAutoConfigurationTest {
     @Test
     public void testReceiveLocalOnlyOptionsAppliedFromEnvOverridesURI() {
         load(EmptyConfiguration.class,
-             "spring.amqp10jms.remoteURL=amqp://127.0.0.1:5672" +
+             "spring.amqp10jms.broker-url=amqp://127.0.0.1:5672" +
                  "?jms.receiveLocalOnly=false&jms.receiveNoWaitLocalOnly=false",
              "spring.amqp10jms.receiveLocalOnly=true",
              "spring.amqp10jms.receiveNoWaitLocalOnly=true");

--- a/amqp-10-jms-spring-boot-autoconfigure/src/test/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSPropertiesTest.java
+++ b/amqp-10-jms-spring-boot-autoconfigure/src/test/java/org/amqphub/spring/boot/jms/autoconfigure/AMQP10JMSPropertiesTest.java
@@ -23,19 +23,14 @@ import org.apache.qpid.jms.JmsConnectionFactory;
 import org.apache.qpid.jms.policy.JmsDefaultDeserializationPolicy;
 import org.junit.Test;
 
+import java.util.Collections;
+
 /**
  * Test for AMQP 1.0 JMS Properties object.
  */
 public class AMQP10JMSPropertiesTest {
 
-    private static final String DEFAULT_REMOTE_URI = "amqp://localhost:5672";
-
     private final AMQP10JMSProperties properties = new AMQP10JMSProperties();
-
-    @Test
-    public void testDefaultURL() {
-        assertEquals(DEFAULT_REMOTE_URI, new AMQP10JMSConnectionFactoryFactory(this.properties).getRemoteURI());
-    }
 
     @Test
     public void testWhiteListDefaultToEmpty() {
@@ -68,8 +63,8 @@ public class AMQP10JMSPropertiesTest {
 
     @Test
     public void testDeserializationPolicyValuesAreApplied() {
-        this.properties.getDeserializationPolicy().setWhiteList("org.apache.qpid.proton.*");
-        this.properties.getDeserializationPolicy().setBlackList("org.apache.activemq..*");
+        this.properties.getDeserializationPolicy().setWhiteList(Collections.singletonList("org.apache.qpid.proton.*"));
+        this.properties.getDeserializationPolicy().setBlackList(Collections.singletonList("org.apache.activemq..*"));
 
         JmsConnectionFactory factory = new AMQP10JMSConnectionFactoryFactory(this.properties).createConnectionFactory(JmsConnectionFactory.class);
 

--- a/amqp-10-jms-spring-boot-examples/amqp-10-jms-spring-boot-hello-world/src/main/resources/application.properties
+++ b/amqp-10-jms-spring-boot-examples/amqp-10-jms-spring-boot-hello-world/src/main/resources/application.properties
@@ -15,4 +15,4 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-spring.amqp10jms.remoteURL=amqp://127.0.0.1:5672
+spring.amqp10jms.broker-url=amqp://127.0.0.1:5672

--- a/amqp-10-jms-spring-boot-examples/amqp-10-jms-spring-boot-reply-service/src/main/resources/application.properties
+++ b/amqp-10-jms-spring-boot-examples/amqp-10-jms-spring-boot-reply-service/src/main/resources/application.properties
@@ -18,4 +18,4 @@
 amqp.host=${MESSAGING_SERVICE_HOST:localhost}
 amqp.port=${MESSAGING_SERVICE_PORT:5672}
 
-spring.amqp10jms.remoteURL=amqp://${amqp.host}:${amqp.port}
+spring.amqp10jms.broker-url=amqp://${amqp.host}:${amqp.port}

--- a/amqp-10-jms-spring-boot-examples/amqp-10-jms-spring-boot-requestor/src/main/resources/application.properties
+++ b/amqp-10-jms-spring-boot-examples/amqp-10-jms-spring-boot-requestor/src/main/resources/application.properties
@@ -18,4 +18,4 @@
 amqp.host=${MESSAGING_SERVICE_HOST:localhost}
 amqp.port=${MESSAGING_SERVICE_PORT:5672}
 
-spring.amqp10jms.remoteURL=amqp://${amqp.host}:${amqp.port}
+spring.amqp10jms.broker-url=amqp://${amqp.host}:${amqp.port}


### PR DESCRIPTION
This commit adds documentation to each configuration key and makes
default values explicit so that the generated meta-data is complete.

The `remoteURL` property has been renamed to `brokerUrl` for consistency
with other messaging-based auto-configuration. Also, not suffixing it
with `URL` prevents the canonical property name to be `remote-u-r-l`.

Finally, blacklist and whitelist are lists so they are now defined as
such in the configuration. That way it can be configured hierarchically
with yml.