### PR TITLE
Update to Qpid JMS 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,26 @@
           <goals>deploy</goals>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java-version</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[17,)</version>
+                  <message>You must use Java 17+ to build</message>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
   </developers>
 
   <properties>
-    <qpid-jms-version>2.1.0</qpid-jms-version>
+    <qpid-jms-version>2.2.0</qpid-jms-version>
     <pooled-jms-version>3.1.0</pooled-jms-version>
 
     <apache-rat-version>0.15</apache-rat-version>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
 
     <maven-gpg-plugin-version>1.6</maven-gpg-plugin-version>
     <maven-eclipse-plugin-version>2.10</maven-eclipse-plugin-version>


### PR DESCRIPTION
Update to Qpid JMS 2.2.0.

Also tweaks compiler config and adds Java 17+ enforcer check to make need for Java 17+ more obvious now that main branch switched from only needing Java 8 to needing 17+.